### PR TITLE
Refactor dxcam capture and fishing flow

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,18 +1,24 @@
-import cv2
-import numpy as np
-import pydirectinput
-import time
+from __future__ import annotations
+
+import configparser
 import ctypes
-import utils
-import dxcam
+import time
+from typing import Type
+
+import cv2
+import pydirectinput
+
 import qte_strategy as strategy
+import utils
+from utils import DxCameraCapture, Rect
+
 ctypes.windll.user32.SetProcessDPIAware()
-GAME_TITLE = "BrownDust II" 
+GAME_TITLE = "BrownDust II"
+BITE_PIXEL_THRESHOLD = 8000
+BITE_TIMEOUT_SECONDS = 15
+CAST_HOLD_SECONDS = 0.38
 
-region = utils.get_window_region(GAME_TITLE)
-config = utils.read_ini()
-
-QTE_STRATEGIES_MAP = {
+QTE_STRATEGIES_MAP: dict[str, Type[strategy.BaseQTEStrategy]] = {
     "烟波湖": strategy.FrostStraitQTEStrategy,
     "浅岸": strategy.FrostStraitQTEStrategy,
     "寒霜海峡": strategy.FrostStraitQTEStrategy,
@@ -20,181 +26,134 @@ QTE_STRATEGIES_MAP = {
     "亚特兰蒂斯": strategy.FrostStraitQTEStrategy,
 }
 
-# ================================== 读取配置 ==================================
 
-hook_top_percent = utils.readConfigAndCastInt(config, "hook", "top_percent")
-hook_bottom_percent = utils.readConfigAndCastInt(config, "hook", "bottom_percent")
-hook_left_percent = utils.readConfigAndCastInt(config, "hook", "left_percent")
-hook_right_percent = utils.readConfigAndCastInt(config, "hook", "right_percent")
+class FishingBot:
+    def __init__(self, config: configparser.ConfigParser, region: Rect) -> None:
+        self.config = config
+        self.region = region
+        self.hook_pos = utils.build_region_from_config(config, "hook", region)
+        self.hook_yellow_range = utils.read_hsv_range(config, "hook", "hook")
+        self.begin_fish_wait_time = utils.read_config_float(config, "time", "begin_fish_wait_time")
+        self.round_end_wait_time = utils.read_config_float(config, "time", "round_end_wait_time")
 
-hook_lower_yellow_hue = utils.readConfigAndCastInt(config, 'hook', 'hook_lower_yellow_hue')
-hook_lower_yellow_saturation = utils.readConfigAndCastInt(config, 'hook', 'hook_lower_yellow_saturation')
-hook_lower_yellow_value = utils.readConfigAndCastInt(config, 'hook', 'hook_lower_yellow_value')
-hook_upper_yellow_hue = utils.readConfigAndCastInt(config, 'hook', 'hook_upper_yellow_hue')
-hook_upper_yellow_saturation = utils.readConfigAndCastInt(config, 'hook', 'hook_upper_yellow_saturation')
-hook_upper_yellow_value = utils.readConfigAndCastInt(config, 'hook', 'hook_upper_yellow_value')
+    def cast_rod(self) -> None:
+        pydirectinput.keyDown("space")
+        time.sleep(CAST_HOLD_SECONDS)
+        pydirectinput.keyUp("space")
+        print(">>> 抛竿完成")
 
-lower_green_hue = utils.readConfigAndCastInt(config, "roi", "lower_green_hue")
-lower_green_saturation = utils.readConfigAndCastInt(config, "roi", "lower_green_saturation")
-lower_green_value = utils.readConfigAndCastInt(config, "roi", "lower_green_value")
-upper_green_hue = utils.readConfigAndCastInt(config, "roi", "upper_green_hue")
-upper_green_saturation = utils.readConfigAndCastInt(config, "roi", "upper_green_saturation")
-upper_green_value = utils.readConfigAndCastInt(config, "roi", "upper_green_value")
-lower_green = np.array([lower_green_hue, lower_green_saturation, lower_green_value])
-upper_green = np.array([upper_green_hue, upper_green_saturation, upper_green_value])
+    def wait_for_bite(self, sct: DxCameraCapture) -> None:
+        print(">>> 等待鱼上钩")
+        wait_start_time = time.time()
+        fail_num = 0
 
-if not region:
-    input(">>> 程序结束，按回车键关闭")
-    exit(1)
-
-hook_pos = (
-    region["left"] + int(region["width"] * hook_left_percent / 100),
-    region["top"] + int(region["height"] * hook_top_percent / 100),
-    region["left"] + int(region["width"] * hook_right_percent / 100),
-    region["top"] + int(region["height"] * hook_bottom_percent / 100),
-)
-
-# ================================== 功能区 ==================================
-
-def cast_rod():
-    pydirectinput.keyDown("space")  # 按下不放
-    time.sleep(0.38)                 # 持续 0.38 秒
-    pydirectinput.keyUp("space")    # 松开
-    print(">>> 抛竿完成")
-
-def wait_for_bite(sct):
-    print(">>> 等待鱼上钩")
-    if not region: return
-    wait_start_time = time.time()
-    wait_end_time = time.time()
-    fail_num = 0
-
-    while True:
-        hook_frame = sct.grab(hook_pos)
-        print(f"hook_pos: {hook_pos}")
-        if hook_frame is None:
-            continue
-        hook_img = np.array(hook_frame)
-        hook_hsv = cv2.cvtColor(hook_img, cv2.COLOR_BGR2HSV)
-        
-        # ori = sct.grab((region["left"], region["top"], region["right"], region["bottom"]))
-        # cv2.imshow("hook", hook_img)
-        # cv2.imshow("ori", ori)
-        # cv2.waitKey(1)
-        
-        hook_yellow = utils.create_color_mask([hook_lower_yellow_hue, hook_lower_yellow_saturation, hook_lower_yellow_value], 
-                                              [hook_upper_yellow_hue, hook_upper_yellow_saturation, hook_upper_yellow_value], 
-                                              hook_hsv, is_dilate=False)
-        hook_yellow_pixel = cv2.countNonZero(hook_yellow)
-        print(f"hook_yellow_pixel: {hook_yellow_pixel}")
-        if hook_yellow_pixel > 8000: 
-            print(">>> 鱼上钩了！") 
-            # 收杆，进入QTE
-            pydirectinput.press("space")
-            return
-
-        # if fail_num > 2:
-        #     print(">>> 背包满了")
-        #     fail_num = 0
-        #     clear_backpack()
-        #     cast_rod()
-        #     continue
-
-        wait_end_time = time.time()
-        # 如果等待时间超过10秒，代表可能有突发情况
-        if wait_end_time - wait_start_time > 15:
-            print(">>> 突发情况")
-            fail_num += 1
-
-            wait_start_time = wait_end_time
-            # 处理切换时间
-            pydirectinput.keyDown("up")  
-            time.sleep(2)
-            pydirectinput.keyUp("up")
-
-            # 点击屏幕
-            # 移动鼠标到窗口中心 (防止点歪)
-            pydirectinput.moveTo(region["left"] + region["width"]//2, region["top"] + region["height"]//2)
-            time.sleep(0.2)
-            # 点击左键
-            pydirectinput.click()
-
-            # 重新抛杆
-            cast_rod()
-            continue   
-    
-def clear_backpack():
-    print(">>> 清理背包")
-    # 打开背包
-    pydirectinput.press("t")
-
-    # 点击一键出售
-    time.sleep(1)
-    one_click_sale_left = int(region["left"] + region["width"] * float(config["backpack"]["one_click_sale_left"]))
-    one_click_sale_top = int(region["top"] + region["height"] * float(config["backpack"]["one_click_sale_top"]))
-    pydirectinput.moveTo(one_click_sale_left, one_click_sale_top)
-    pydirectinput.click()
-
-    # 点击全选
-    time.sleep(1)
-    select_all_left = int(region["left"] + region["width"] * float(config["backpack"]["select_all_left"]))
-    select_all_top = int(region["top"] + region["height"] * float(config["backpack"]["select_all_top"]))
-    pydirectinput.moveTo(select_all_left, select_all_top)
-    pydirectinput.click()
-
-    # 点击打钩按钮
-    circle_check_left = int(region["left"] + region["width"] * float(config["backpack"]["circle_check_left"]))
-    circle_check_top = int(region["top"] + region["height"] * float(config["backpack"]["circle_check_top"]))
-    pydirectinput.moveTo(circle_check_left, circle_check_top)
-    pydirectinput.click()
-
-    # 点击确认按钮
-    time.sleep(0.5)
-    dialog_confirm_left = int(region["left"] + region["width"] * float(config["backpack"]["dialog_confirm_left"]))
-    dialog_confirm_top = int(region["top"] + region["height"] * float(config["backpack"]["dialog_confirm_top"]))
-    pydirectinput.moveTo(dialog_confirm_left, dialog_confirm_top)
-    pydirectinput.click()
-
-    # 退出背包
-    time.sleep(0.5)
-    quit_backpack_left = int(region["left"] + region["width"] * float(config["backpack"]["quit_backpack_left"]))
-    quit_backpack_top = int(region["top"] + region["height"] * float(config["backpack"]["quit_backpack_top"]))
-    pydirectinput.moveTo(quit_backpack_left, quit_backpack_top)
-    pydirectinput.click()
-    time.sleep(0.5)
-
-def main():
-    print("可选钓鱼地点：")
-    for idx, location in enumerate(QTE_STRATEGIES_MAP.keys()):
-        print(f"{idx + 1}: {location}")
-    selected_location = input(">>> 输入数字对应的钓鱼地点：")
-    
-    if (int(selected_location) - 1) in range(len(QTE_STRATEGIES_MAP)):
-        selected_location_name = list(QTE_STRATEGIES_MAP.keys())[int(selected_location) - 1]
-        print(f">>> 你选择了: {selected_location_name}")
-        QTEStrategyClass = QTE_STRATEGIES_MAP[selected_location_name]
-    else:
-        print(">>> 选择无效，默认使用寒霜海峡策略")
-        QTEStrategyClass = strategy.FrostStraitQTEStrategy
-        
-    qte_strategy = QTEStrategyClass(config, region)
-    
-    time.sleep(float(config["time"]["begin_fish_wait_time"]))
-
-    with dxcam.create(output_color="BGR") as sct: 
         while True:
-            # 1. 抛竿
-            cast_rod()
-            
-            # 2. 等待上钩
-            wait_for_bite(sct)
-            
-            # 3. QTE
-            qte_strategy.play_qte(sct, region) 
-            
-            # 4. 结束
-            print("================这轮的钓鱼结束================")
-            time.sleep(float(config["time"]["round_end_wait_time"]))      
+            hook_frame = sct.grab(self.hook_pos)
+            if hook_frame is None:
+                continue
 
-if __name__ == "__main__": 
+            hook_hsv = cv2.cvtColor(hook_frame, cv2.COLOR_BGR2HSV)
+            hook_yellow = utils.create_color_mask(
+                self.hook_yellow_range.lower,
+                self.hook_yellow_range.upper,
+                hook_hsv,
+                is_dilate=False,
+            )
+            hook_yellow_pixel = cv2.countNonZero(hook_yellow)
+            print(f"hook_yellow_pixel: {hook_yellow_pixel}")
+            if hook_yellow_pixel > BITE_PIXEL_THRESHOLD:
+                print(">>> 鱼上钩了！")
+                pydirectinput.press("space")
+                return
+
+            if time.time() - wait_start_time <= BITE_TIMEOUT_SECONDS:
+                continue
+
+            print(">>> 突发情况，尝试恢复钓鱼状态")
+            fail_num += 1
+            wait_start_time = time.time()
+            self.recover_from_timeout()
+
+            # 预留后续做自动清背包或更复杂恢复逻辑
+            if fail_num >= 9999:
+                self.clear_backpack()
+                fail_num = 0
+
+    def recover_from_timeout(self) -> None:
+        pydirectinput.keyDown("up")
+        time.sleep(2)
+        pydirectinput.keyUp("up")
+
+        center_x, center_y = self.region.center
+        pydirectinput.moveTo(center_x, center_y)
+        time.sleep(0.2)
+        pydirectinput.click()
+        self.cast_rod()
+
+    def clear_backpack(self) -> None:
+        print(">>> 清理背包")
+        pydirectinput.press("t")
+        self._click_backpack_button("one_click_sale_left", "one_click_sale_top", delay=1)
+        self._click_backpack_button("select_all_left", "select_all_top", delay=1)
+        self._click_backpack_button("circle_check_left", "circle_check_top")
+        self._click_backpack_button("dialog_confirm_left", "dialog_confirm_top", delay=0.5)
+        self._click_backpack_button("quit_backpack_left", "quit_backpack_top", delay=0.5)
+
+    def _click_backpack_button(self, left_key: str, top_key: str, *, delay: float = 0) -> None:
+        if delay:
+            time.sleep(delay)
+        pos = utils.build_point_from_ratio(
+            self.region,
+            left_ratio=utils.read_config_float(self.config, "backpack", left_key),
+            top_ratio=utils.read_config_float(self.config, "backpack", top_key),
+        )
+        pydirectinput.moveTo(*pos)
+        pydirectinput.click()
+
+    def choose_strategy(self) -> strategy.BaseQTEStrategy:
+        print("可选钓鱼地点：")
+        locations = list(QTE_STRATEGIES_MAP.keys())
+        for idx, location in enumerate(locations, start=1):
+            print(f"{idx}: {location}")
+
+        selected_location = input(">>> 输入数字对应的钓鱼地点：")
+        try:
+            selected_index = int(selected_location) - 1
+        except ValueError:
+            selected_index = -1
+
+        if selected_index in range(len(locations)):
+            selected_name = locations[selected_index]
+            print(f">>> 你选择了: {selected_name}")
+            strategy_class = QTE_STRATEGIES_MAP[selected_name]
+        else:
+            print(">>> 选择无效，默认使用寒霜海峡策略")
+            strategy_class = strategy.FrostStraitQTEStrategy
+
+        return strategy_class(self.config, self.region)
+
+    def run(self) -> None:
+        qte_strategy = self.choose_strategy()
+        time.sleep(self.begin_fish_wait_time)
+
+        with DxCameraCapture(output_color="BGR") as sct:
+            while True:
+                self.cast_rod()
+                self.wait_for_bite(sct)
+                qte_strategy.play_qte(sct)
+                print("================这轮的钓鱼结束================")
+                time.sleep(self.round_end_wait_time)
+
+
+def main() -> None:
+    region = utils.get_window_region(GAME_TITLE)
+    if not region:
+        input(">>> 程序结束，按回车键关闭")
+        raise SystemExit(1)
+
+    config = utils.read_ini()
+    FishingBot(config, region).run()
+
+
+if __name__ == "__main__":
     main()

--- a/qte_strategy.py
+++ b/qte_strategy.py
@@ -1,245 +1,184 @@
+from __future__ import annotations
+
+import configparser
 import time
+
 import cv2
 import numpy as np
 import pydirectinput
+
 import utils
+from utils import Rect
+
 
 class BaseQTEStrategy:
-    def __init__(self, config, region):
-        self.longest_keep_time = utils.readConfigAndCastInt(config, "time", "longest_keep_time")
-        self.fish_end_wait_time = float(config["time"]["fish_end_wait_time"])
-        
-        lower_white_hue = utils.readConfigAndCastInt(config, 'roi', 'lower_white_hue')
-        lower_white_saturation = utils.readConfigAndCastInt(config, 'roi', 'lower_white_saturation')
-        lower_white_value = utils.readConfigAndCastInt(config, 'roi', 'lower_white_value')
-        upper_white_hue = utils.readConfigAndCastInt(config, 'roi', 'upper_white_hue')
-        upper_white_saturation = utils.readConfigAndCastInt(config, 'roi', 'upper_white_saturation')
-        upper_white_value = utils.readConfigAndCastInt(config, 'roi', 'upper_white_value')
-        self.lower_white = np.array([lower_white_hue, lower_white_saturation, lower_white_value]) 
-        self.upper_white = np.array([upper_white_hue, upper_white_saturation, upper_white_value])
+    def __init__(self, config: configparser.ConfigParser, region: Rect) -> None:
+        self.region = region
+        self.longest_keep_time = utils.read_config_int(config, "time", "longest_keep_time")
+        self.fish_end_wait_time = utils.read_config_float(config, "time", "fish_end_wait_time")
 
-        lower_yellow_hue = utils.readConfigAndCastInt(config, "roi", "lower_yellow_hue")
-        lower_yellow_saturation = utils.readConfigAndCastInt(config, "roi", "lower_yellow_saturation")
-        lower_yellow_value = utils.readConfigAndCastInt(config, "roi", "lower_yellow_value")
-        upper_yellow_hue = utils.readConfigAndCastInt(config, "roi", "upper_yellow_hue")
-        upper_yellow_saturation = utils.readConfigAndCastInt(config, "roi", "upper_yellow_saturation")
-        upper_yellow_value = utils.readConfigAndCastInt(config, "roi", "upper_yellow_value")
-        self.lower_yellow = np.array([lower_yellow_hue, lower_yellow_saturation, lower_yellow_value])
-        self.upper_yellow = np.array([upper_yellow_hue, upper_yellow_saturation, upper_yellow_value])
-        
-        time_lower_green_hue = utils.readConfigAndCastInt(config, 'roi', 'time_lower_green_hue')
-        time_lower_green_saturation = utils.readConfigAndCastInt(config, 'roi', 'time_lower_green_saturation')
-        time_lower_green_value = utils.readConfigAndCastInt(config, 'roi', 'time_lower_green_value')
-        time_upper_green_hue = utils.readConfigAndCastInt(config, 'roi', 'time_upper_green_hue')
-        time_upper_green_saturation = utils.readConfigAndCastInt(config, 'roi', 'time_upper_green_saturation')
-        time_upper_green_value = utils.readConfigAndCastInt(config, 'roi', 'time_upper_green_value')
-        self.time_lower_green = np.array([time_lower_green_hue, time_lower_green_saturation, time_lower_green_value])
-        self.time_upper_green = np.array([time_upper_green_hue, time_upper_green_saturation, time_upper_green_value])
-
-        time_lower_red_hue = utils.readConfigAndCastInt(config, 'roi', 'time_lower_red_hue')
-        time_lower_red_saturation = utils.readConfigAndCastInt(config, 'roi', 'time_lower_red_saturation')
-        time_lower_red_value = utils.readConfigAndCastInt(config, 'roi', 'time_lower_red_value')
-        time_upper_red_hue = utils.readConfigAndCastInt(config, 'roi', 'time_upper_red_hue')
-        time_upper_red_saturation = utils.readConfigAndCastInt(config, 'roi', 'time_upper_red_saturation')
-        time_upper_red_value = utils.readConfigAndCastInt(config, 'roi', 'time_upper_red_value')
-        self.time_lower_red = np.array([time_lower_red_hue, time_lower_red_saturation, time_lower_red_value])
-        self.time_upper_red = np.array([time_upper_red_hue, time_upper_red_saturation, time_upper_red_value])
-
-        roi_top_percent = utils.readConfigAndCastInt(config, "roi", "top_percent")
-        roi_bottom_percent = utils.readConfigAndCastInt(config, "roi", "bottom_percent")
-        roi_left_percent = utils.readConfigAndCastInt(config, "roi", "left_percent")
-        roi_right_percent = utils.readConfigAndCastInt(config, "roi", "right_percent")
-        
-        time_top_percent = utils.readConfigAndCastInt(config, 'roi', 'time_top_percent')
-        time_bottom_percent = utils.readConfigAndCastInt(config, 'roi', 'time_bottom_percent')
-        time_left_percent = utils.readConfigAndCastInt(config, 'roi', 'time_left_percent')
-        time_right_percent = utils.readConfigAndCastInt(config, 'roi', 'time_right_percent')
-
-        self.roi_pos = (
-            region["left"] + int(region["width"] * roi_left_percent / 100),
-            region["top"] + int(region["height"] * roi_top_percent / 100),
-            region["left"] + int(region["width"] * roi_right_percent / 100),
-            region["top"] + int(region["height"] * roi_bottom_percent / 100)
+        self.white_range = utils.read_hsv_range(config, "roi", "white")
+        self.yellow_range = utils.read_hsv_range(config, "roi", "yellow")
+        self.time_green_range = utils.read_hsv_range_from_keys(
+            config,
+            "roi",
+            lower_prefix="time_lower_green",
+            upper_prefix="time_upper_green",
         )
-
-        self.rot_pos = (
-            region["left"] + int(region["width"] * time_left_percent / 100),
-            region["top"] + int(region["height"] * time_top_percent / 100),
-            region["left"] + int(region["width"] * time_right_percent / 100),
-            region["top"] + int(region["height"] * time_bottom_percent / 100)
+        self.time_red_range = utils.read_hsv_range_from_keys(
+            config,
+            "roi",
+            lower_prefix="time_lower_red",
+            upper_prefix="time_upper_red",
         )
-    def play_qte(self, sct, region):
-        """核心执行方法，子类必须重写这个方法"""
+        self.roi_pos = utils.build_region_from_config(config, "roi", region)
+        self.time_pos = utils.build_region_from_config(config, "roi", region, prefix="time")
+
+    def play_qte(self, sct: utils.DxCameraCapture) -> None:
         raise NotImplementedError("子类必须实现 play_qte() 方法")
-    
-    def finish_fishing(self, window_center_x, window_center_y):
-        # 移动鼠标到窗口中心 (防止点歪)
+
+    def _grab_hsv_frame(self, sct: utils.DxCameraCapture, region: Rect) -> np.ndarray | None:
+        frame = sct.grab(region)
+        if frame is None:
+            return None
+        return cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+
+    def _grab_qte_frames(self, sct: utils.DxCameraCapture) -> tuple[np.ndarray, np.ndarray] | None:
+        roi_hsv = self._grab_hsv_frame(sct, self.roi_pos)
+        time_hsv = self._grab_hsv_frame(sct, self.time_pos)
+        if roi_hsv is None or time_hsv is None:
+            return None
+        return roi_hsv, time_hsv
+
+    def _time_bar_visible(self, time_hsv: np.ndarray) -> bool:
+        mask_green = utils.create_color_mask(
+            self.time_green_range.lower,
+            self.time_green_range.upper,
+            time_hsv,
+            is_dilate=False,
+        )
+        mask_red = utils.create_color_mask(
+            self.time_red_range.lower,
+            self.time_red_range.upper,
+            time_hsv,
+            is_dilate=False,
+        )
+        score = cv2.countNonZero(mask_red) * 20 + cv2.countNonZero(mask_green) * 10
+        return score > 1000
+
+    def _find_cursor_x(self, roi_hsv: np.ndarray) -> int | None:
+        mask_cursor = utils.create_color_mask(
+            self.white_range.lower,
+            self.white_range.upper,
+            roi_hsv,
+            is_dilate=False,
+        )
+        col_sums = np.sum(mask_cursor, axis=0)
+        if np.max(col_sums) <= 0:
+            return None
+        return int(np.argmax(col_sums))
+
+    def _finish_fishing(self) -> None:
+        time.sleep(self.fish_end_wait_time)
+        window_center_x, window_center_y = self.region.center
         pydirectinput.moveTo(window_center_x, window_center_y)
         time.sleep(0.2)
-        # 点击左键
         pydirectinput.click()
-    
-class FrostStraitQTEStrategy(BaseQTEStrategy):
-    """默认钓鱼点：只看黄色条"""
-    def __init__(self, config, region):
-        super().__init__(config, region)
-        lower_red_hue = utils.readConfigAndCastInt(config, "roi", "lower_red_hue")
-        lower_red_saturation = utils.readConfigAndCastInt(config, "roi", "lower_red_saturation")
-        lower_red_value = utils.readConfigAndCastInt(config, "roi", "lower_red_value")
-        upper_red_hue = utils.readConfigAndCastInt(config, "roi", "upper_red_hue")
-        upper_red_saturation = utils.readConfigAndCastInt(config, "roi", "upper_red_saturation")
-        upper_red_value = utils.readConfigAndCastInt(config, "roi", "upper_red_value")
-        self.lower_red = np.array([lower_red_hue, lower_red_saturation, lower_red_value])
-        self.upper_red = np.array([upper_red_hue, upper_red_saturation, upper_red_value])
 
-    def play_qte(self, sct, region):
-        print(">>> 开始 QTE...")
+    def _yellow_mask(self, roi_hsv: np.ndarray) -> np.ndarray:
+        return utils.create_color_mask(self.yellow_range.lower, self.yellow_range.upper, roi_hsv)
 
-        no_bar_frames = 0
-        start_time = time.time()
-        while time.time() - start_time < self.longest_keep_time:
-            # 提取qte条的范围
-            roi_frame = sct.grab(self.roi_pos)
-            rot_frame = sct.grab(self.rot_pos)
-            if roi_frame is None or rot_frame is None:
-                continue
-            roi = np.array(roi_frame)
-            rot = np.array(rot_frame)
-            
-            # DXCAM 输出 BGRA
-            roi_hsv = cv2.cvtColor(roi, cv2.COLOR_BGRA2BGR) 
-            roi_hsv = cv2.cvtColor(roi_hsv, cv2.COLOR_BGR2HSV)
-            rot_hsv = cv2.cvtColor(rot, cv2.COLOR_BGRA2BGR)
-            rot_hsv = cv2.cvtColor(rot_hsv, cv2.COLOR_BGR2HSV)
-            
-            # 提取黄色区域
-            mask_yellow = utils.create_color_mask(self.lower_yellow, self.upper_yellow, roi_hsv)
-            
-            # 提取时间条的绿色和红色区域
-            mask_green_time = utils.create_color_mask(self.time_lower_green, self.time_upper_green, rot_hsv, is_dilate=False)
-            mask_red_time = utils.create_color_mask(self.time_lower_red, self.time_upper_red, rot_hsv, is_dilate=False)
-            time_red_pixel_count = cv2.countNonZero(mask_red_time) * 20
-            time_green_pixel_count = cv2.countNonZero(mask_green_time) * 10
-            
-            # 防止有其他有元素干扰
-            if time_red_pixel_count + time_green_pixel_count > 1000: 
-                no_bar_frames = 0
-                # 找到光标位置
-                mask_cursor = utils.create_color_mask(self.lower_white, self.upper_white, roi_hsv, is_dilate=False)
-                col_sums = np.sum(mask_cursor, axis=0)
-                # 找到白色像素最多的那一列的索引
-                cursor_x = np.argmax(col_sums)
-                
-                if (self.solve_ice_trouble(roi_hsv)):
-                    continue
-                
-                # 如果画面里没有白色，cursor_x 可能是 0，需要防呆
-                if np.max(col_sums) > 0: 
-                    check_y = roi.shape[0] // 2
-                    if mask_yellow[check_y, cursor_x]:
-                        print(">>> 击中了黄色区域")
-                        pydirectinput.press("space")     
-                
-            else:
-                no_bar_frames += 1
-
-                if no_bar_frames > 30:
-                    print(">>> 钓鱼结束")
-                    # 等待鱼结束动画
-                    time.sleep(self.fish_end_wait_time)
-                    self.finish_fishing(region["left"] + region["width"]//2, region["top"] + region["height"]//2)
-                    break  
-                        
-    def solve_ice_trouble(self, roi_hsv):
-        """
-        检测并解决冰冻状态
-        :param roi_hsv: 当前QTE画面的 HSV 数据
-        :return: True 如果检测到冰冻并执行了操作，False 如果无冰冻
-        """
-        mask = cv2.inRange(roi_hsv, self.lower_red, self.upper_red) 
-        
-        # 计算红色像素数量，阈值设为 10 左右
-        if cv2.countNonZero(mask) > 5: 
-            print(">>> 检测到冰冻！正在破冰 (按空格)...")
-            pydirectinput.press('space')
-            # 为了防止按太快游戏不识别，给个极短的间隔
-            time.sleep(0.05) 
+    def _on_bar_disappeared(self, no_bar_frames: int) -> bool:
+        if no_bar_frames > 30:
+            print(">>> 钓鱼结束")
+            self._finish_fishing()
             return True
-        
         return False
-    
-class AbyssMawQTEStrategy(BaseQTEStrategy):
-    def __init__(self, config, region):
+
+
+class FrostStraitQTEStrategy(BaseQTEStrategy):
+    """默认钓鱼点：只看黄色条，并处理破冰。"""
+
+    def __init__(self, config: configparser.ConfigParser, region: Rect) -> None:
         super().__init__(config, region)
-        lower_blue_hue = utils.readConfigAndCastInt(config, "roi", "lower_blue_hue")
-        lower_blue_saturation = utils.readConfigAndCastInt(config, "roi", "lower_blue_saturation")
-        lower_blue_value = utils.readConfigAndCastInt(config, "roi", "lower_blue_value")
-        upper_blue_hue = utils.readConfigAndCastInt(config, "roi", "upper_blue_hue")
-        upper_blue_saturation = utils.readConfigAndCastInt(config, "roi", "upper_blue_saturation")
-        upper_blue_value = utils.readConfigAndCastInt(config, "roi", "upper_blue_value")
-        self.lower_blue = np.array([lower_blue_hue, lower_blue_saturation, lower_blue_value])
-        self.upper_blue = np.array([upper_blue_hue, upper_blue_saturation, upper_blue_value])
+        self.red_range = utils.read_hsv_range(config, "roi", "red")
 
-    def play_qte(self, sct, region):
+    def play_qte(self, sct: utils.DxCameraCapture) -> None:
         print(">>> 开始 QTE...")
-
         no_bar_frames = 0
         start_time = time.time()
-        while time.time() - start_time < self.longest_keep_time:
-            # 提取qte条的范围
-            roi_frame = sct.grab(self.roi_pos)
-            rot_frame = sct.grab(self.rot_pos)
-            if roi_frame is None or rot_frame is None:
-                continue
-            roi = np.array(roi_frame)
-            rot = np.array(rot_frame)
-            
-            # DXCAM 输出 BGRA
-            roi_hsv = cv2.cvtColor(roi, cv2.COLOR_BGRA2BGR) 
-            roi_hsv = cv2.cvtColor(roi_hsv, cv2.COLOR_BGR2HSV)
-            rot_hsv = cv2.cvtColor(rot, cv2.COLOR_BGRA2BGR)
-            rot_hsv = cv2.cvtColor(rot_hsv, cv2.COLOR_BGR2HSV)
-            
-            # 提取黄色区域
-            mask_yellow = utils.create_color_mask(self.lower_yellow, self.upper_yellow, roi_hsv)
-            mask_blue = utils.create_color_mask(self.lower_blue, self.upper_blue, roi_hsv)
-            
-            # 提取时间条的绿色和红色区域
-            mask_green_time = utils.create_color_mask(self.time_lower_green, self.time_upper_green, rot_hsv, is_dilate=False)
-            mask_red_time = utils.create_color_mask(self.time_lower_red, self.time_upper_red, rot_hsv, is_dilate=False)
-            time_red_pixel_count = cv2.countNonZero(mask_red_time) * 20
-            time_green_pixel_count = cv2.countNonZero(mask_green_time) * 10
-            
-            # 防止有其他有元素干扰
-            if time_red_pixel_count + time_green_pixel_count > 1000: 
-                no_bar_frames = 0
-                # 找到光标位置
-                mask_cursor = utils.create_color_mask(self.lower_white, self.upper_white, roi_hsv, is_dilate=False)
-                col_sums = np.sum(mask_cursor, axis=0)
-                # 找到白色像素最多的那一列的索引
-                cursor_x = np.argmax(col_sums)
-                
-                # 如果画面里没有白色，cursor_x 可能是 0，需要防呆
-                if np.max(col_sums) > 0: 
-                    check_y = roi.shape[0] // 2
-                    
-                    mask_yellow_pixel_count = cv2.countNonZero(mask_yellow)
-                    
-                    if mask_yellow_pixel_count > 300:
-                        if mask_yellow[check_y, cursor_x]:
-                            print(">>> 击中了黄色区域")
-                            pydirectinput.press("space")
-                    else:
-                        if mask_blue[check_y, cursor_x]:
-                            print(">>> 击中了蓝色区域")
-                            pydirectinput.press("space")
-                
-            else:
-                no_bar_frames += 1
 
-                if no_bar_frames > 30:
-                    print(">>> 钓鱼结束")
-                    # 等待鱼结束动画
-                    time.sleep(self.fish_end_wait_time)
-                    self.finish_fishing(region["left"] + region["width"]//2, region["top"] + region["height"]//2)
+        while time.time() - start_time < self.longest_keep_time:
+            frames = self._grab_qte_frames(sct)
+            if frames is None:
+                continue
+
+            roi_hsv, time_hsv = frames
+            if not self._time_bar_visible(time_hsv):
+                no_bar_frames += 1
+                if self._on_bar_disappeared(no_bar_frames):
                     break
+                continue
+
+            no_bar_frames = 0
+            if self.solve_ice_trouble(roi_hsv):
+                continue
+
+            cursor_x = self._find_cursor_x(roi_hsv)
+            if cursor_x is None:
+                continue
+
+            mask_yellow = self._yellow_mask(roi_hsv)
+            check_y = mask_yellow.shape[0] // 2
+            if mask_yellow[check_y, cursor_x]:
+                print(">>> 击中了黄色区域")
+                pydirectinput.press("space")
+
+    def solve_ice_trouble(self, roi_hsv: np.ndarray) -> bool:
+        mask = cv2.inRange(roi_hsv, self.red_range.lower, self.red_range.upper)
+        if cv2.countNonZero(mask) > 5:
+            print(">>> 检测到冰冻！正在破冰 (按空格)...")
+            pydirectinput.press("space")
+            time.sleep(0.05)
+            return True
+        return False
+
+
+class AbyssMawQTEStrategy(BaseQTEStrategy):
+    def __init__(self, config: configparser.ConfigParser, region: Rect) -> None:
+        super().__init__(config, region)
+        self.blue_range = utils.read_hsv_range(config, "roi", "blue")
+
+    def play_qte(self, sct: utils.DxCameraCapture) -> None:
+        print(">>> 开始 QTE...")
+        no_bar_frames = 0
+        start_time = time.time()
+
+        while time.time() - start_time < self.longest_keep_time:
+            frames = self._grab_qte_frames(sct)
+            if frames is None:
+                continue
+
+            roi_hsv, time_hsv = frames
+            if not self._time_bar_visible(time_hsv):
+                no_bar_frames += 1
+                if self._on_bar_disappeared(no_bar_frames):
+                    break
+                continue
+
+            no_bar_frames = 0
+            cursor_x = self._find_cursor_x(roi_hsv)
+            if cursor_x is None:
+                continue
+
+            yellow_mask = self._yellow_mask(roi_hsv)
+            blue_mask = utils.create_color_mask(self.blue_range.lower, self.blue_range.upper, roi_hsv)
+            check_y = yellow_mask.shape[0] // 2
+
+            if cv2.countNonZero(yellow_mask) > 300:
+                if yellow_mask[check_y, cursor_x]:
+                    print(">>> 击中了黄色区域")
+                    pydirectinput.press("space")
+            elif blue_mask[check_y, cursor_x]:
+                print(">>> 击中了蓝色区域")
+                pydirectinput.press("space")

--- a/utils.py
+++ b/utils.py
@@ -1,114 +1,211 @@
-import win32gui
+from __future__ import annotations
+
 import configparser
 import os
 import sys
-import numpy as np
-import cv2
-import dxcam
+from dataclasses import dataclass
+from typing import Iterable
 
-def get_window_region(window_title):
-    """
-    根据窗口标题找到窗口的 (left, top, width, height)
-    """
+import cv2
+import numpy as np
+import win32gui
+
+
+@dataclass(frozen=True)
+class Rect:
+    left: int
+    top: int
+    right: int
+    bottom: int
+
+    @property
+    def width(self) -> int:
+        return self.right - self.left
+
+    @property
+    def height(self) -> int:
+        return self.bottom - self.top
+
+    @property
+    def center(self) -> tuple[int, int]:
+        return (self.left + self.width // 2, self.top + self.height // 2)
+
+    def as_tuple(self) -> tuple[int, int, int, int]:
+        return (self.left, self.top, self.right, self.bottom)
+
+
+@dataclass(frozen=True)
+class HSVRange:
+    lower: np.ndarray
+    upper: np.ndarray
+
+
+class DxCameraCapture:
+    """对 dxcam 的轻量封装，统一输出 BGR 图像。"""
+
+    def __init__(self, output_color: str = "BGR") -> None:
+        import dxcam
+
+        self._camera = dxcam.create(output_color=output_color)
+
+    def grab(self, region: Rect | tuple[int, int, int, int]) -> np.ndarray | None:
+        target = region.as_tuple() if isinstance(region, Rect) else region
+        frame = self._camera.grab(region=target)
+        if frame is None:
+            return None
+        if frame.ndim == 3 and frame.shape[2] == 4:
+            return cv2.cvtColor(frame, cv2.COLOR_BGRA2BGR)
+        return frame
+
+    def __enter__(self) -> "DxCameraCapture":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        stop = getattr(self._camera, "stop", None)
+        if callable(stop):
+            stop()
+
+
+def get_window_region(window_title: str) -> Rect | None:
+    """根据窗口标题找到窗口区域。"""
     hwnd = win32gui.FindWindow(None, window_title)
     if not hwnd:
         print(f"错误: 未找到标题为 '{window_title}' 的窗口")
         return None
-    
-    # 获取窗口在屏幕上的坐标 (left, top, right, bottom)
-    rect = win32gui.GetWindowRect(hwnd)
-    x, y, right, bottom = rect
-    w = right - x
-    h = bottom - y
-    
-    # 返回 dxcam 需要的字典格式
-    return {'left': x, 'top': y, 'right': right, 'bottom': bottom, 'width': w, 'height': h}
 
-# def to_dxcam_region(region):
-#     """
-#     将 {'left','top','width','height'} 转为 dxcam 使用的 (left, top, right, bottom)
-#     """
-#     return (
-#         region["left"],
-#         region["top"],
-#         region["left"] + region["width"],
-#         region["top"] + region["height"],
-#     )
+    left, top, right, bottom = win32gui.GetWindowRect(hwnd)
+    return Rect(left=left, top=top, right=right, bottom=bottom)
 
-# class DxcamCapture:
-#     def __init__(self,):
-#         self._camera = dxcam.create()
 
-#     def grab(self, region):
-#         return self._camera.grab(region=to_dxcam_region(region))
-
-#     def __enter__(self):
-#         return self
-
-#     def __exit__(self, exc_type, exc, tb):
-#         if hasattr(self._camera, "stop"):
-#             try:
-#                 self._camera.stop()
-#             except Exception:
-#                 pass
-
-def get_resource_path(relative_path):
-    """
-    获取资源文件的绝对路径。
-    用于访问打包进 exe 内部的图片资源。
-    """
-    if hasattr(sys, '_MEIPASS'):
-        # PyInstaller 会把资源解压到 sys._MEIPASS 临时目录下
+def get_resource_path(relative_path: str) -> str:
+    """获取资源文件的绝对路径。"""
+    if hasattr(sys, "_MEIPASS"):
         return os.path.join(sys._MEIPASS, relative_path)
-    
-    # 普通运行模式，直接返回当前目录下的文件
     return os.path.join(os.path.abspath("."), relative_path)
 
-def read_ini(filename: str = "config.ini"):
-    """
-    从ini文件读取配置文件，自动适配 .py 脚本运行和 .exe 打包运行环境
-    :param filename: 文件名 (例如 "config.ini")
-    :return: config对象
-    """
-    # 1. 获取当前程序的基础路径
-    if getattr(sys, 'frozen', False):
-        # 如果是打包后的 .exe 运行，获取 .exe 所在的目录
+
+def read_ini(filename: str = "config.ini") -> configparser.ConfigParser:
+    """读取 ini 配置文件，不存在时自动写入默认配置。"""
+    if getattr(sys, "frozen", False):
         base_path = os.path.dirname(sys.executable)
     else:
-        # 如果是 .py 脚本运行，获取当前脚本所在的目录
         base_path = os.path.dirname(os.path.abspath(__file__))
 
-    # 2. 将基础路径和文件名拼接成【绝对路径】
     full_path = os.path.join(base_path, filename)
-    
-    print(f">>> 正在读取配置文件路径: {full_path}") 
+    print(f">>> 正在读取配置文件路径: {full_path}")
+
     config = configparser.ConfigParser()
-    
     if not os.path.exists(full_path):
         print(f">>> 配置文件未找到，正在生成默认配置: {full_path}")
-        try:
-            with open(full_path, 'w', encoding='utf-8-sig') as f:
-                f.write(DEFAULT_CONFIG_CONTENT)
-        except Exception as e:
-            print(f">>> 无法写入配置文件: {e}")
-        
+        with open(full_path, "w", encoding="utf-8-sig") as file:
+            file.write(DEFAULT_CONFIG_CONTENT)
+
     config.read(full_path, encoding="utf-8-sig")
     return config
 
-def readConfigAndCastInt(config, item, key):
-    return int(config[item][key])
 
-def create_color_mask(lower_color, upper_color, roi_hsv, is_dilate=True):
+def read_config_int(config: configparser.ConfigParser, section: str, key: str) -> int:
+    return config.getint(section, key)
+
+
+def read_config_float(config: configparser.ConfigParser, section: str, key: str) -> float:
+    return config.getfloat(section, key)
+
+
+def read_hsv_range(config: configparser.ConfigParser, section: str, prefix: str) -> HSVRange:
+    return read_hsv_range_from_keys(
+        config,
+        section,
+        lower_prefix=f"{prefix}_lower",
+        upper_prefix=f"{prefix}_upper",
+    )
+
+
+def read_hsv_range_from_keys(
+    config: configparser.ConfigParser,
+    section: str,
+    *,
+    lower_prefix: str,
+    upper_prefix: str,
+) -> HSVRange:
+    lower = np.array(
+        [
+            read_config_int(config, section, f"{lower_prefix}_hue"),
+            read_config_int(config, section, f"{lower_prefix}_saturation"),
+            read_config_int(config, section, f"{lower_prefix}_value"),
+        ]
+    )
+    upper = np.array(
+        [
+            read_config_int(config, section, f"{upper_prefix}_hue"),
+            read_config_int(config, section, f"{upper_prefix}_saturation"),
+            read_config_int(config, section, f"{upper_prefix}_value"),
+        ]
+    )
+    return HSVRange(lower=lower, upper=upper)
+
+
+def build_region_from_percent(
+    window_region: Rect,
+    *,
+    left_percent: float,
+    top_percent: float,
+    right_percent: float,
+    bottom_percent: float,
+) -> Rect:
+    return Rect(
+        left=window_region.left + int(window_region.width * left_percent / 100),
+        top=window_region.top + int(window_region.height * top_percent / 100),
+        right=window_region.left + int(window_region.width * right_percent / 100),
+        bottom=window_region.top + int(window_region.height * bottom_percent / 100),
+    )
+
+
+def build_region_from_config(
+    config: configparser.ConfigParser,
+    section: str,
+    window_region: Rect,
+    *,
+    prefix: str = "",
+) -> Rect:
+    key_prefix = f"{prefix}_" if prefix else ""
+    return build_region_from_percent(
+        window_region,
+        left_percent=read_config_int(config, section, f"{key_prefix}left_percent"),
+        top_percent=read_config_int(config, section, f"{key_prefix}top_percent"),
+        right_percent=read_config_int(config, section, f"{key_prefix}right_percent"),
+        bottom_percent=read_config_int(config, section, f"{key_prefix}bottom_percent"),
+    )
+
+
+def build_point_from_ratio(
+    window_region: Rect,
+    *,
+    left_ratio: float,
+    top_ratio: float,
+) -> tuple[int, int]:
+    return (
+        int(window_region.left + window_region.width * left_ratio),
+        int(window_region.top + window_region.height * top_ratio),
+    )
+
+
+def create_color_mask(
+    lower_color: Iterable[int] | np.ndarray,
+    upper_color: Iterable[int] | np.ndarray,
+    roi_hsv: np.ndarray,
+    *,
+    is_dilate: bool = True,
+) -> np.ndarray:
     lower = np.array(lower_color)
     upper = np.array(upper_color)
     mask = cv2.inRange(roi_hsv, lower, upper)
     if is_dilate:
-        # 7x7 的卷积核
-        kernel = np.ones((7, 7), np.uint8) 
+        kernel = np.ones((7, 7), np.uint8)
         mask = cv2.dilate(mask, kernel, iterations=2)
     return mask
 
-# 默认的配置内容
+
 DEFAULT_CONFIG_CONTENT = """[hook]
 ; 感叹号位置
 top_percent = 31


### PR DESCRIPTION
### Motivation
- Replace the fragile ad-hoc mss→dxcam replacement and eliminate duplicated coordinate / color logic by centralizing capture and config helpers to improve maintainability and extensibility.
- Encapsulate the main fishing flow so casting, bite detection, timeout recovery and backpack handling are single-responsibility methods and easier to extend or test.
- Reduce repeated HSV/region handling in QTE strategies and normalize dxcam frames to a consistent format for simpler image-processing code.

### Description
- Add typed utilities in `utils.py`: `Rect`, `HSVRange`, a `DxCameraCapture` wrapper around `dxcam`, config readers and helpers (`read_config_int`, `read_config_float`, `read_hsv_range`, `build_region_from_config`, `build_point_from_ratio`) and keep `create_color_mask` for reuse.
- Replace the script-level flow with a `FishingBot` class in `main.py` that exposes `cast_rod`, `wait_for_bite`, `recover_from_timeout`, `clear_backpack`, `choose_strategy` and `run`, and uses `DxCameraCapture` for frame grabs.
- Move common QTE behavior into `BaseQTEStrategy` in `qte_strategy.py` (shared frame grabbing, HSV conversion, time-bar visibility check, cursor detection and finish behavior) and simplify `FrostStraitQTEStrategy` / `AbyssMawQTEStrategy` to only implement map-specific logic.
- Normalize frame color handling (BGRA→BGR), tighten region math, and rename/standardize config access helpers so code is clearer and easier to extend.

### Testing
- Ran `python -m py_compile main.py utils.py qte_strategy.py` and the files compiled with no errors.
- Ran `git diff --check` to verify there are no whitespace/merge issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba5d870c4c8331a8e6f821ebc5977c)